### PR TITLE
Use module syntax for importing TBXML

### DIFF
--- a/GPX/GPXElementSubclass.h
+++ b/GPX/GPXElementSubclass.h
@@ -7,7 +7,7 @@
 //
 
 #import "GPXElement.h"
-#import "TBXML.h"
+#import <TBXML/TBXML.h>
 
 @interface GPXElement ()
 


### PR DESCRIPTION
This fixes a build error when `#import <iOS_GPX_Framework/GPX.h>` is added to the bridging header (which was preventing the library from being used from Swift).